### PR TITLE
Mandelbrot example : fixed rescaling, mouse position and custom uniforms

### DIFF
--- a/addons/compute_shader_studio/compute_shader_studio_2d.gd
+++ b/addons/compute_shader_studio/compute_shader_studio_2d.gd
@@ -75,7 +75,7 @@ var uniforms		: Array[RDUniform]
 var uniform_params 	: RDUniform
 var uniform_user 	: RDUniform
 
-var uniform_user_data   : PackedByteArray = []
+var uniform_user_data   : PackedByteArray = PackedByteArray([0])
 
 var bindings		: Array = []
 
@@ -147,9 +147,6 @@ layout(binding = """+str(i+2)+""") buffer Data"""+str(i)+""" {
 	input_params.append(current_pass)
 	var input_params_bytes := input_params.to_byte_array()
 	buffer_params = rd.storage_buffer_create(input_params_bytes.size(), input_params_bytes)
-	
-	if uniform_user_data.size() == 0 :
-		uniform_user_data.resize(4)
 	buffer_user   = rd.storage_buffer_create(uniform_user_data.size(), uniform_user_data)
 	
 	# Creation of nb_buffers Buffers of type Int32
@@ -223,10 +220,8 @@ func display_values(disp : Node, values : PackedByteArray): # PackedInt32Array):
 		var old_width  : float = disp.texture.get_width()
 		var old_height : float = disp.texture.get_height()
 		disp.set_texture(tex)
-		var new_width  : float = disp.texture.get_width()
-		var new_height : float = disp.texture.get_height()
-		disp.scale *= Vector2(old_width/new_width, old_height/new_height)
-		
+		disp.scale *= Vector2(old_width/WSX, old_height/WSY)
+
 	else :
 		disp.set_texture(tex)
 
@@ -269,14 +264,10 @@ func _update_uniforms():
 	
 	input_params.append(step)
 	input_params.append(current_pass)
-	
-	if data.size() > 0 :
-		var pos : Vector2 = get_viewport().get_mouse_position()
-		var sprite : Sprite2D = data[0]
-		pos.x = (pos.x - sprite.position.x)  / sprite.scale.x + WSX/2
-		pos.y = (pos.y - sprite.position.y)  / sprite.scale.y + WSY/2
-		input_params.append(pos.x)
-		input_params.append(pos.y)
+
+	var pos : Vector2 = screen_to_data0(get_viewport().get_mouse_position())
+	input_params.append(pos.x)
+	input_params.append(pos.y)
 	
 	var input_params_bytes := input_params.to_byte_array()
 	buffer_params = rd.storage_buffer_create(input_params_bytes.size(), input_params_bytes)
@@ -328,3 +319,12 @@ func _on_button_step():
 
 func _on_button_play():
 	pause = false # Replace with function body.
+
+func screen_to_data0(pos : Vector2):
+	if data.size() <= 0 :
+		return Vector2(0, 0)
+
+	var sprite : Sprite2D = data[0]
+	pos.x = (pos.x - sprite.position.x)  / sprite.scale.x + WSX/2
+	pos.y = (pos.y - sprite.position.y)  / sprite.scale.y + WSY/2
+	return pos;

--- a/addons/compute_shader_studio/compute_shader_studio_2d.gd
+++ b/addons/compute_shader_studio/compute_shader_studio_2d.gd
@@ -199,32 +199,21 @@ func display_all_values():
 		if is_instance_valid(data[b]):
 			display_values(data[b], output_bytes)
 
-var rescaled:bool = false
 func display_values(disp : Node, values : PackedByteArray): # PackedInt32Array):
-	if disp is Sprite2D:
-		var image_format : int = Image.FORMAT_RGBA8
-		var old_width:float  = disp.texture.get_width()
-		var old_height:float = disp.texture.get_height()
-		var image := Image.create_from_data(WSX, WSY, false, image_format, values)
-		disp.set_texture(ImageTexture.create_from_image(image))
-		var new_width:float  = disp.texture.get_width()
-		var new_height:float = disp.texture.get_height()
-		# Rescale the disp node2D to maintain the same size
-		if rescaled == false:
-			disp.scale = disp.scale * Vector2(old_width/new_width, old_height/new_height)
-			rescaled = true
-	if disp is TextureRect:
-		var image_format : int = Image.FORMAT_RGBA8
-		#var old_width:float  = disp.texture.get_width()
-		#var old_height:float = disp.texture.get_height()
-		var image := Image.create_from_data(WSX, WSY, false, image_format, values)
-		disp.set_texture(ImageTexture.create_from_image(image))
-		#var new_width:float  = disp.texture.get_width()
-		#var new_height:float = disp.texture.get_height()
-		# Rescale the disp node2D to maintain the same size
-		#if rescaled == false:
-		#	disp.scale = disp.scale * Vector2(old_width/new_width, old_height/new_height)
-		#	rescaled = true
+	var img : Image = Image.create_from_data(WSX, WSY, false, Image.FORMAT_RGBA8, values)
+	var tex : Texture2D = ImageTexture.create_from_image(img)
+	
+	if disp is Sprite2D :
+		var old_width  : float = disp.texture.get_width()
+		var old_height : float = disp.texture.get_height()
+		disp.set_texture(tex)
+		var new_width  : float = disp.texture.get_width()
+		var new_height : float = disp.texture.get_height()
+		disp.scale *= Vector2(old_width/new_width, old_height/new_height)
+		
+	else :
+		disp.set_texture(tex)
+
 
 var step  : int = 0
 

--- a/examples/example_mandelbrot.cpp
+++ b/examples/example_mandelbrot.cpp
@@ -1,0 +1,101 @@
+/* MANDELBROT 
+	Josselin SCOUARNEC
+	Feb 2024
+*/
+
+#define MAX_IT 500
+#define PI 3.141592
+#define TWO_PI (2.0*3.141592)
+
+#define RADIUS 2.0
+
+layout(binding = 1) buffer UserUniforms {
+    float u_zoom;
+    float u_pos_x;
+    float u_pos_y;
+};
+
+#define PALETTE_SIZE 16
+const vec3 palette[PALETTE_SIZE] = {
+    vec3(0.0, 0.5, 0.5),
+    vec3(0.0, 0.0, 0.5),
+    vec3(0.0, 0.0, 1.0),
+    vec3(0.0, 0.5, 1.0),
+    vec3(0.0, 1.0, 1.0),
+    vec3(0.5, 1.0, 0.5),
+    vec3(1.0, 1.0, 0.0),
+    vec3(1.0, 0.5, 0.0),
+    vec3(1.0, 0.0, 0.0),
+    vec3(1.0, 0.5, 0.0),
+    vec3(1.0, 1.0, 0.0),
+    vec3(0.5, 1.0, 0.5),
+    vec3(0.0, 1.0, 1.0),
+    vec3(0.0, 0.5, 1.0),
+    vec3(0.0, 0.0, 1.0),
+    vec3(0.0, 0.0, 0.5),
+};
+
+int rgb_to_int(vec3 c) {
+    return 0xFF000000
+        | int(255.0*c.x)
+        | int(255.0*c.y) << 8
+        | int(255.0*c.z) << 16;
+}
+
+vec3 coloring(vec2 z, uint it) {
+    if (it >= MAX_IT) {
+        return vec3(0.0);
+    }
+
+    // Smoothing
+    float logz = log(z.x*z.x + z.y*z.y) / 2;
+    float nu = log(logz / log(2)) / log(2);
+    float smooth_iter = it + 1.0 - nu;
+
+    // Index in palette
+    float index = 3 * log(smooth_iter) * PALETTE_SIZE / log(MAX_IT);
+
+    // Linear interpolation
+    vec3 c1 = palette[int(index)];
+    vec3 c2 = palette[(int(index) + 1) % PALETTE_SIZE];
+    return mix(c1, c2, fract(index));
+}
+
+vec3 fractal(vec2 z, vec2 c) {
+    uint it;
+    for (it = 0; it < MAX_IT && z.x*z.x + z.y*z.y < RADIUS*RADIUS; it++) {
+        // z := z*z + c     (a+bi) * (a+bi) = a*a - b*b + 2abi
+        z = vec2(z.x*z.x - z.y*z.y + c.x, 2*z.x*z.y + c.y);
+    }
+    return coloring(z, it);
+}
+
+vec2 screen_to_world(vec2 screen) {
+    vec2 wsize  = vec2(WSX, WSY);
+    vec2 center = vec2(u_pos_x, u_pos_y);
+    return center + (screen / wsize - 0.5) * 4.0 / u_zoom;
+}
+
+void main() {
+    uint p = gl_GlobalInvocationID.x + gl_GlobalInvocationID.y * WSX;
+
+    // Julia
+    vec2 wsize  = vec2(WSX, WSY);
+    vec2 z = (gl_GlobalInvocationID.xy / wsize - 0.5) * 4.0;
+    vec2 c = screen_to_world(vec2(mousex, mousey));
+    vec3 color = fractal(z, c);
+    data_1[p] = rgb_to_int(color);
+
+    // Cursor
+    if ((mousex >= 0 && gl_GlobalInvocationID.x == mousex)
+     || (mousey >= 0 && gl_GlobalInvocationID.y == mousey))
+    {
+        data_0[p] = rgb_to_int(vec3(1.0, 0.0, 0.0));
+    }
+    else { // Mandelbrot
+        vec2 z = screen_to_world(gl_GlobalInvocationID.xy);
+        vec2 c = z;
+        vec3 color = fractal(z, c);
+        data_0[p] = rgb_to_int(color);
+    }
+}

--- a/examples/example_mandelbrot.gd
+++ b/examples/example_mandelbrot.gd
@@ -1,0 +1,40 @@
+extends Node
+
+var css : Node
+
+var zoom : float = 1.0
+var pos : Vector2 = Vector2(-0.75, 0)
+
+var grab : Vector2
+var grabbing : bool = false
+
+func screen_to_world(screen : Vector2):
+	var pos_data0 : Vector2 = css.screen_to_data0(screen)
+	var wsize : Vector2 = Vector2(css.WSX, css.WSY);
+	return pos + (pos_data0 / wsize - Vector2(0.5, 0.5)) * 4.0 / zoom;
+
+func _ready():
+	css = get_node("ComputeShaderStudio2D")
+	css.uniform_user_data.resize(4*3)
+
+func _process(_delta):
+	css.uniform_user_data.encode_float(0, zoom)
+	css.uniform_user_data.encode_float(4, pos.x)
+	css.uniform_user_data.encode_float(8, pos.y)
+
+func _input(event):
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_WHEEL_UP :
+			zoom *= 1.1
+		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN :
+			zoom /= 1.1
+		elif event.button_index == MOUSE_BUTTON_LEFT :
+			if event.pressed : # Start panning
+				grab = screen_to_world(event.position)
+				grabbing = true
+			else : # Stop panning
+				grabbing = false
+	
+	elif event is InputEventMouse and grabbing : # Panning
+		var delta : Vector2 = screen_to_world(event.position) - grab
+		pos -= delta

--- a/examples/example_mandelbrot.tscn
+++ b/examples/example_mandelbrot.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://c0mt2oesmx768"]
 
-[ext_resource type="Script" path="res://example_mandelbrot.gd" id="1_5gp20"]
+[ext_resource type="Script" path="res://examples/example_mandelbrot.gd" id="1_5gp20"]
 [ext_resource type="Script" path="res://addons/compute_shader_studio/compute_shader_studio_2d.gd" id="1_t5cx1"]
 [ext_resource type="Texture2D" uid="uid://demftcowdd5c6" path="res://examples/icon.svg" id="2_dyrad"]
 

--- a/examples/example_mandelbrot.tscn
+++ b/examples/example_mandelbrot.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=4 format=3 uid="uid://c0mt2oesmx768"]
+
+[ext_resource type="Script" path="res://example_mandelbrot.gd" id="1_5gp20"]
+[ext_resource type="Script" path="res://addons/compute_shader_studio/compute_shader_studio_2d.gd" id="1_t5cx1"]
+[ext_resource type="Texture2D" uid="uid://demftcowdd5c6" path="res://examples/icon.svg" id="2_dyrad"]
+
+[node name="example_mandelbrot" type="Node2D"]
+script = ExtResource("1_5gp20")
+
+[node name="ComputeShaderStudio2D" type="Node" parent="." node_paths=PackedStringArray("data")]
+script = ExtResource("1_t5cx1")
+WSX = 512
+WSY = 512
+glsl_file = "res://examples/example_mandelbrot.cpp"
+data = [NodePath("../mandelbrot"), NodePath("../julia")]
+
+[node name="mandelbrot" type="Sprite2D" parent="."]
+position = Vector2(308, 316)
+scale = Vector2(4, 4)
+texture = ExtResource("2_dyrad")
+
+[node name="julia" type="Sprite2D" parent="."]
+position = Vector2(861, 316)
+scale = Vector2(4, 4)
+texture = ExtResource("2_dyrad")
+
+[node name="Label" type="Label" parent="."]
+offset_left = 233.0
+offset_top = 25.0
+offset_right = 353.0
+offset_bottom = 48.0
+text = "Mandelbrot Set"
+
+[node name="Label2" type="Label" parent="."]
+offset_left = 815.0
+offset_top = 25.0
+offset_right = 935.0
+offset_bottom = 48.0
+text = "Julia Set"


### PR DESCRIPTION
Mandelbrot set visualization example, use the mouse to pan and zoom. The Julia set associated to the mouse position is shown.

Other changes :
- Every data sprite is now rescaled on every frame, before only the first one would be rescaled on the first frame. There are maybe better ways to do it.
- Mouse position within `data_0` can be accessed by the shader with `mousex` and `mousey`.
- In the shader custom uniforms can be defined on binding 1 (see `example_mandelbrot.cpp`) : 
```glsl
layout(binding = 1) buffer UserUniforms {
    int u_foo;
    float u_bar;
};
```

They can be set from a script by writing to the `uniform_user_data` byte array (see `example_mandelbrot.gd`) :
```godot
var css : Node

func _ready():
    css = get_node("ComputeShaderStudio2D")
    css.uniform_user_data.resize(8) # sizeof(int) + sizeof(float) 

func _process(_delta):
    var foo : int = 99
    var bar : float = 3.14
    css.uniform_user_data.encode_s32(0, foo)
    css.uniform_user_data.encode_float(4, bar)
```